### PR TITLE
flag for printing all details of a service

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,25 @@
 #!/usr/bin/env node
 'use strict'
 
+var mri = require('mri')
+
+var argv = mri(process.argv.slice(2), {
+  boolean: ['help', 'h']
+})
+
+if (argv.help || argv.h) {
+  process.stdout.write(`\
+Usage:
+  bonjour-browser [name]
+Example:
+  bonjour-browser my-apple-tv
+`)
+  process.exit(0)
+}
+
 var bonjour = require('bonjour')()
 
-var name = process.argv[2]
+var name = argv._[2]
 var found = Object.create(null)
 
 bonjour.find({ type: name }, function (service) {

--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@
 var mri = require('mri')
 
 var argv = mri(process.argv.slice(2), {
-  boolean: ['help', 'h']
+  boolean: ['help', 'h', 'print-details']
 })
 
 if (argv.help || argv.h) {
-  process.stdout.write(`\
+  console.log(`\
 Usage:
-  bonjour-browser [name]
+  bonjour-browser [--print-details] [name]
 Example:
   bonjour-browser my-apple-tv
 `)
@@ -20,10 +20,11 @@ Example:
 var bonjour = require('bonjour')()
 
 var name = argv._[2]
-var found = Object.create(null)
+var printDetails = !!argv['print-details']
 
+var found = Object.create(null)
 bonjour.find({ type: name }, function (service) {
   if (service.fqdn in found) return
   found[service.fqdn] = true
-  console.log(service.fqdn)
+  console.log(printDetails ? service : service.fqdn)
 })

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var bonjour = require('bonjour')()
 
 var name = process.argv[2]
-var found = {}
+var found = Object.create(null)
 
 bonjour.find({ type: name }, function (service) {
   if (service.fqdn in found) return

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "bonjour": "index.js"
   },
   "dependencies": {
-    "bonjour": "^3.2.0"
+    "bonjour": "^3.2.0",
+    "mri": "^1.1.4"
   },
   "devDependencies": {
     "standard": "^5.4.1"


### PR DESCRIPTION
This CLI is useful, thanks! But it would be even more helpful if I could get raw data.

For now, I just added a `--print-details` boolean flag that prints all of `service` instead of `service.fqdn`.

I can also imagine more flexible ways to do this:

- Let it print JSON instead, allowing users to filter for props using e.g. [`jq`](https://stedolan.github.io/jq/).
- Let it accept a [`_.get`](https://lodash.com/docs/4.17.14#get)-style property path, allowing me to get any *single* property of each service.

What do you think? Thanks for your review time!